### PR TITLE
feat(gui): ファンスイッチ表示を削除

### DIFF
--- a/app/src/gui/gui.py
+++ b/app/src/gui/gui.py
@@ -86,10 +86,6 @@ class MainWindow(QDialog):
         self.lapTimeLabel.updateLapTimeLabel(message)
         self.timeIconValueBox.updateTime()
         self.fuelPressTitleValueBox.updateValueLabel(dashMachineInfo.fuelPress)
-        self.fanSwitchStateTitleValueBox.updateBoolValueLabel(
-            dashMachineInfo.fanEnabled
-        )
-        self.fanSwitchStateTitleValueBox.updateFanWarning(dashMachineInfo.fanEnabled)
         self.brakeBiasTitleValueBox.updateValueLabel(dashMachineInfo.brakePress.bias)
         self.tpsTitleValueBox.updateValueLabel(dashMachineInfo.throttlePosition)
         self.bpsFTitleValueBox.updateValueLabel(dashMachineInfo.brakePress.front)
@@ -108,9 +104,8 @@ class MainWindow(QDialog):
         self.oilTempTitleValueBox = TitleValueBox("Oil Temp")
         self.oilPressTitleValueBox = TitleValueBox("Oil Press")
         self.fuelPressTitleValueBox = TitleValueBox("Fuel Press")
-        self.fanSwitchStateTitleValueBox = TitleValueBox("Fan Switch")
         self.switchStateRemiderLabel = TitleValueBox(
-            "SWITCH CHECK! \n1. Fan \n2. TPS MAX"
+            "SWITCH CHECK! \nTPS MAX"
         )
         self.switchStateRemiderLabel.titleLabel.setAlignment(QtCore.Qt.AlignVCenter)
         self.switchStateRemiderLabel.titleLabel.setFontScale(0.25)
@@ -159,9 +154,8 @@ class MainWindow(QDialog):
         layout.addWidget(self.oilTempTitleValueBox, 1, 0)
         layout.addWidget(self.oilPressTitleValueBox, 1, 1)
         layout.addWidget(self.fuelPressTitleValueBox, 0, 1)
-        layout.addWidget(self.fanSwitchStateTitleValueBox, 2, 0)
         # layout.addWidget(self.brakeBiasTitleValueBox, 2, 1)
-        layout.addWidget(self.switchStateRemiderLabel, 2, 1)
+        layout.addWidget(self.switchStateRemiderLabel, 2, 0, 1, 2)
         layout.setRowStretch(0, 1)
         layout.setRowStretch(1, 1)
         layout.setRowStretch(2, 1)


### PR DESCRIPTION
## 概要
インパネ画面から「Fan Switch」表示を削除（ファンスイッチはもう不要）。

## 変更 (`app/src/gui/gui.py`)
- **「Fan Switch」値ボックス** (`fanSwitchStateTitleValueBox`) を撤去（生成・更新・レイアウト配置）
- **SWITCH CHECK リマインダから Fan 項目を削除**: `SWITCH CHECK! 1. Fan 2. TPS MAX` → `SWITCH CHECK! TPS MAX`
- 空いた左カラム下段は SWITCH CHECK リマインダを**横2列にスパン**して埋め

## 残置
- データ層の `fanEnabled`（`can_listeners.py` の 0x5F3 デコード / `models.py` / UDP転送）は**残置**。画面表示のみ削除。CAN側からも消す場合は別途。
- 未使用になった `TitleValueBox.updateFanWarning()` は残置。

## テスト
- `python -m py_compile` OK。実画面(PyQt)は表示環境が要るため未確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)